### PR TITLE
Adding relative method in path interface

### DIFF
--- a/docs/path.md
+++ b/docs/path.md
@@ -243,26 +243,42 @@ let parseMyPath = Path.parse("/home/user/dir/file.name/")
 
 ### `Path.relative(from, to)`
 
-returns the relative path `from` to `to`. If `from` and `to` each resolve to the same path after calling `resolve` on each, a zero-length string is returned. If a zero-length string is passed as from or to, the current working directory will be used instead of the zero-length strings.
+returns the relative path `from` to `to`. If `from` and `to` each resolve to the same path after calling `resolve` on each, a zero-length string is returned. If a zero-length string is passed as from or to, the current working directory will be used instead of the zero-length strings. `From` here is expected to be path of a directory.
 
 #### Type Definition
 
 ```reason
-let relative: (~from: string, ~_to: string) => unit;
+let relative: (~from: string, ~_to: string) => string;
 ```
 
 #### Usage
 
-**\*Path.relative needs to be implemented\***
+```reason
+let relativePath = Path.relative("/home/user/dir", "user/foo/file.name")
+/*
+ ../file.name
+*/
+```
 
-Please open a pull request if you are interested in contributing,
-no code is needed, we will help answer questions and push you
-in the right direction.
+---
 
-Repo URL: https://github.com/kennetpostigo/lwt-node
+### `Path.relativeFilePath(from, to)`
+
+returns the relative path `from` to `to`. If `from` and `to` each resolve to the same path after calling `resolve` on each, a zero-length string is returned. If a zero-length string is passed as from or to, the current working directory will be used instead of the zero-length strings. `From` here is expected to be path of a file.
+
+#### Type Definition
 
 ```reason
+let relativeFilePath: (~from: string, ~_to: string) => string;
+```
 
+#### Usage
+
+```reason
+let relativePath = Path.relative("/home/user/dir/file.name", "user/foo/file.name")
+/*
+ ../file.name
+*/
 ```
 
 ---

--- a/src/path.re
+++ b/src/path.re
@@ -88,7 +88,9 @@ let resolve = paths => {
         switch path {
         | ""
         | "./"
-        | ".\\" => ()
+        | ".\\" =>
+          keepJoining := false;
+          rePath := Sys.getcwd();
         | "/"
         | "\\" =>
           keepJoining := false;
@@ -102,7 +104,7 @@ let resolve = paths => {
             keepJoining := false;
           | _ =>
             rePath :=
-              String.length(rePath^) == 0 ? path : path ++ sep ++ rePath^
+              String.length(rePath^) == 0 ? path : path ++ sep ++ rePath^;
           }
         }
       );
@@ -111,7 +113,31 @@ let resolve = paths => {
   normalize(rePath^);
 };
 
-let relative = (~from, ~_to) => ();
+let relative = (~from, ~_to) => {
+  let pathFrom = String.length(from) > 0 ? normalize(from) : "";
+  let pathTo = String.length(_to) > 0 ? normalize(_to) : "";
+  let dirFrom = Filename.is_relative(pathFrom) ? resolve([pathFrom]) : pathFrom;
+  let dirTo = Filename.is_relative(pathTo) ? resolve([pathTo]) : pathTo;
+  if (dirFrom == dirTo) {
+    "";
+  } else {
+    let (fromDiff, toDiff) = RenodeUtils.removeCommonPath(dirFrom, dirTo);
+    RenodeUtils.getRelativePath(~path1=fromDiff, ~path2=toDiff, ~isFilePath=false);
+  }
+};
+
+let relativeFilePath = (~from, ~_to) => {
+  let pathFrom = String.length(from) > 0 ? normalize(from) : "";
+  let pathTo = String.length(_to) > 0 ? normalize(_to) : "";
+  let dirFrom = Filename.is_relative(pathFrom) ? resolve([pathFrom]) : pathFrom;
+  let dirTo = Filename.is_relative(pathTo) ? resolve([pathTo]) : pathTo;
+  if (dirFrom == dirTo) {
+    "";
+  } else {
+    let (fromDiff, toDiff) = RenodeUtils.removeCommonPath(dirFrom, dirTo);
+    RenodeUtils.getRelativePath(~path1=fromDiff, ~path2=toDiff, ~isFilePath=true);
+  }
+};
 
 let parse = path => {
   let root = path.[0] == charSep ? Some(sep) : None;

--- a/src/path.rei
+++ b/src/path.rei
@@ -26,16 +26,8 @@ let normalize: string => string;
 
 let parse: string => pathObject;
 
-[@ocaml.deprecated
-  {|
-    Path.relative has yet to be implemented.
-    Please open a pull request if you are interested in contributing,
-    no code is needed, we will help answer questions and push you
-    in the right direction.
+let relative: (~from: string, ~_to: string) => string;
 
-    Repo URL: https://github.com/kennetpostigo/lwt-node
-  |}
-]
-let relative: (~from: string, ~_to: string) => unit;
+let relativeFilePath: (~from: string, ~_to: string) => string;
 
 let resolve: list(string) => string;

--- a/src/renodeUtils.re
+++ b/src/renodeUtils.re
@@ -6,6 +6,47 @@ let charSep =
   | _ => '/'
   };
 
+let rec removeCommonPath = (~path1, ~path2) => {
+  let subp1 = switch (String.index_from(path1, 1, charSep)) {
+    | index => String.sub(path1, 0, index)
+    | exception _ => path1
+  };
+  let subp2 = switch (String.index_from(path2, 1, charSep)) {
+    | index => String.sub(path2, 0, index)
+    | exception _ => path2
+  };
+  if (subp1 != "" && subp1 == subp2) {
+    let len = String.length(subp1);
+    let newp1 = String.sub(path1, len, String.length(path1) - len);
+    let newp2 = String.sub(path2, len, String.length(path2) - len);
+    removeCommonPath(~path1=newp1, ~path2=newp2);
+  } else {
+    let p1 = switch (String.get(path1, 0) == charSep) {
+      | true => String.sub(path1, 1, String.length(path1) - 1)
+      | false => path1
+      | exception _ => path1
+    };
+    let p2 = switch (String.get(path2, 0) == charSep) {
+      | true => String.sub(path2, 1, String.length(path2) - 1)
+      | false => path2
+      | exception _ => path2
+    };
+    (p1, p2);
+  }
+};
+
+let rec getRelativePath = (~path1, ~path2, ~isFilePath): string => {
+  switch (String.index_from(path1, 1, charSep)) {
+    | index => {
+        let len = String.length(String.sub(path1, 1, index));
+        let subPath1 = String.sub(path1, len, String.length(path1) - len);
+        getRelativePath(~path1=subPath1, ~path2=(".." ++ sep ++ path2), ~isFilePath=isFilePath);
+      }
+    | exception Not_found when (String.length(path1) > 0 && isFilePath == false) => (".." ++ sep ++ path2)
+    | exception _ => path2
+  };
+};
+
 let rec resolveRelativePaths = (~path, ~newPath) =>
   if (String.length(path) == 0) {
     newPath;

--- a/tests/pathTests.re
+++ b/tests/pathTests.re
@@ -146,6 +146,61 @@ let isNotAbsolute = () =>
     Path.isAbsolute("./foo/bar/index.html")
   );
 
+let relativeWithSamePath = () =>
+  Alcotest.(check(string))(
+    "Path.relative",
+    "",
+    Path.relative("bar/index.html", "bar/index.html")
+  );
+
+let relativeWithUNNormalizedPath = () =>
+  Alcotest.(check(string))(
+    "Path.relative",
+    "",
+    Path.relative("bar//index.html", "./bar/index.html")
+  );
+let relativeWithDifferentPath1 = () =>
+Alcotest.(check(string))(
+  "Path.relative",
+  "../../index.html",
+  Path.relative("bar/foo", "index.html")
+);
+
+let relativeFilePath = () =>
+Alcotest.(check(string))(
+  "Path.relative",
+  "../../index.html",
+  Path.relativeFilePath("bar/foo/index.html", "index.html")
+);
+
+let relativeWithDifferentPath2 = () =>
+Alcotest.(check(string))(
+  "Path.relative",
+  "../../index.html",
+  Path.relative("foo/bar/baz/foo", "foo/bar/index.html")
+);
+
+let relativeWithAbsolutePath = () =>
+Alcotest.(check(string))(
+  "Path.relative",
+  "../../aaa/index.html",
+  Path.relative("/foo/bar/baz/bbb", "/foo/bar/aaa/index.html")
+);
+
+let relativeWithEmptyPath = () =>
+Alcotest.(check(string))(
+  "Path.relative",
+  "index.html",
+  Path.relative("", "index.html")
+);
+
+let relativeWithBothPathEmpty = () =>
+Alcotest.(check(string))(
+  "Path.relative",
+  "",
+  Path.relative("", "")
+);
+
 let join = () =>
   Alcotest.(check(string))(
     "Path.join",
@@ -195,7 +250,14 @@ let resolvePath2 = () =>
     Path.resolve(["wwwroot", "static_files/png/", "../gif/image.gif"])
   );
 
-let parsePath0 = () =>
+  let resolvePath3 = () =>
+  Alcotest.(check(string))(
+    "Path.resolve 3",
+    Sys.getcwd(),
+    Path.resolve([""])
+  );
+
+  let parsePath0 = () =>
   Alcotest.(check(string))(
     "Path.parse 0",
     "{ root: Some(\"/\"), dir: Some(\"/home/user\"), base: Some(\"dir\"), ext: None, name: Some(\"dir\") }",
@@ -256,6 +318,12 @@ let pathTestSet = [
   ("Path.format with name and ext", `Slow, formatWithRootNameExt),
   ("Path.isAbsolute with abolute path", `Slow, isAbsolute),
   ("Path.isAbsolute with relative path", `Slow, isNotAbsolute),
+  ("Path.relative with same paths", `Slow, relativeWithSamePath),
+  ("Path.relative with different paths", `Slow, relativeWithDifferentPath1),
+  ("Path.relative with different long paths", `Slow, relativeWithDifferentPath2),
+  ("Path.relative with empty paths", `Slow, relativeWithEmptyPath),
+  ("Path.relative with both paths empty", `Slow, relativeWithBothPathEmpty),
+  ("Path.relativeFilePath", `Slow, relativeFilePath),
   ("Path.join", `Slow, join),
   ("Path.join up a directory", `Slow, joinUpADirectory),
   ("Path.join unormalized string", `Slow, joinUnormalizedString),

--- a/tests/renodeUtilsTests.re
+++ b/tests/renodeUtilsTests.re
@@ -84,7 +84,41 @@ let resolveRelativePathRelative10 = () =>
     RenodeUtils.resolveRelativePaths("foo/bar./baz/", "")
   );
 
-let handleDotDotNoDots0 = () =>
+let removeCommonPathPath1 = () => 
+  Alcotest.(check(string))(
+    "RenodeUtils.removeCommonPath path1",
+    "baz/index.html",
+    {
+      let (path1, _) = RenodeUtils.removeCommonPath("/foo/bar/baz/index.html", "/foo/bar/index.html");
+      path1;
+    }
+  );
+
+  let removeCommonPathPath2 = () => 
+  Alcotest.(check(string))(
+    "RenodeUtils.removeCommonPath path2",
+    "index.html",
+    {
+      let (_, path2) = RenodeUtils.removeCommonPath("/foo/bar/baz/index.html", "/foo/bar/index.html");
+      path2;
+    }
+  );
+
+  let getRelativePath = () =>
+  Alcotest.(check(string))(
+    "RenodeUtils.getRelativePath",
+    "../../../../aaa/index.html",
+    RenodeUtils.getRelativePath("foo/bar/baz/bbb", "aaa/index.html", false)
+  );
+
+  let getRelativeFilePath = () =>
+  Alcotest.(check(string))(
+    "RenodeUtils.getRelativePath for small path",
+    "../../../index.html",
+    RenodeUtils.getRelativePath("foo/bar/baz/index.html", "index.html", true)
+  );
+
+  let handleDotDotNoDots0 = () =>
   Alcotest.(check(string))(
     "RenodeUtils.handleDotDot no dots 0",
     "foo/bar/baz",
@@ -306,6 +340,10 @@ let utilsTestSet = [
     `Slow,
     resolveRelativePathRelative10
   ),
+  ("RenodeUtils.getRelativePath relative paths for directory", `Slow, getRelativePath),
+  ("RenodeUtils.getRelativePath relative paths for file", `Slow, getRelativeFilePath),
+  ("RenodeUtils.removeCommonPath relative paths path one", `Slow, removeCommonPathPath1),
+  ("RenodeUtils.removeCommonPath relative paths path two", `Slow, removeCommonPathPath2),
   ("RenodeUtils.handleDotDot no dots 0", `Slow, handleDotDotNoDots0),
   ("RenodeUtils.handleDotDot no dots 1", `Slow, handleDotDotNoDots1),
   ("RenodeUtils.handleDotDot no dots 2", `Slow, handleDotDotNoDots2),


### PR DESCRIPTION
Hey @kennetpostigo , great project.
I was checking it out. I want to contribute to the project and thus I created this PR for a method.

I want to implement `path.relative` method. What I understand about the method is:

1. returns the relative path from -> to
2. if from and to each resolve to the same path return zero length string
3. if either of from or to are zero length string use current working directory instead of them

Please suggest if I am missing out on anything.