### PR TITLE
implement fdatasyncSync and fsyncSync

### DIFF
--- a/src/fs.re
+++ b/src/fs.re
@@ -54,7 +54,9 @@ let fchownSync = (~fd, ~uid, ~gid) => Unix.fchown(fd, uid, gid);
 
 let fdatasync = fd => Lwt_unix.fdatasync(fd);
 
-let fdatasyncSync = fd => ();
+let fdatasyncSync = fd => Lwt_unix.of_unix_file_descr(fd)
+  |> fdatasync
+  |> Node.run;
 
 let fstat = fd => Lwt_unix.fstat(fd);
 
@@ -62,7 +64,9 @@ let fstatSync = fd => Unix.fstat(fd);
 
 let fsync = fd => Lwt_unix.fsync(fd);
 
-let fsyncSync = fd => ();
+let fsyncSync = fd => Lwt_unix.of_unix_file_descr(fd)
+  |> fsync
+  |> Node.run;
 
 let ftruncate = (~len=0, fd) => Lwt_unix.ftruncate(fd, len);
 

--- a/src/fs.rei
+++ b/src/fs.rei
@@ -90,15 +90,6 @@ let fchownSync: (~fd: syncFileDescr, ~uid: int, ~gid: int) => unit;
 
 let fdatasync: asyncFileDescr => Node.t(unit);
 
-[@ocaml.deprecated
-  {|
-    Fs.fdatasyncSync has yet to be implemented.
-    Please open a Work-In-Progress pull request if you are interested in contributing.
-    We will help answer questions and push you in the right direction.
-
-    Repo URL: https://github.com/kennetpostigo/reason-node
-  |}
-]
 let fdatasyncSync: syncFileDescr => unit;
 
 let fstat: asyncFileDescr => Node.t(asyncStats);
@@ -107,15 +98,6 @@ let fstatSync: syncFileDescr => syncStats;
 
 let fsync: asyncFileDescr => Node.t(unit);
 
-[@ocaml.deprecated
-  {|
-    Fs.fsyncSync has yet to be implemented.
-    Please open a Work-In-Progress pull request if you are interested in contributing.
-    We will help answer questions and push you in the right direction.
-
-    Repo URL: https://github.com/kennetpostigo/reason-node
-  |}
-]
 let fsyncSync: syncFileDescr => unit;
 
 let ftruncate: (~len: int=?, Lwt_unix.file_descr) => Node.t(unit);


### PR DESCRIPTION
Hi there! I saw these two had an async function implemented but no `sync` counterpart so I just converted the fd from `Unix` to `Lwt_unix` and ran the promise to get the value. Not sure if that's good enough for you or prefer some other way to do this.

Sadly, `Unix` does not have that yet, but something could be done like in janestreet's core https://github.com/janestreet/core/blob/master/src/unix_stubs.c#L325-L341